### PR TITLE
v4.0 now is possible to choose the Authentication Mechanism (SCRAM-SHA-1 or MONGODB-CR). Default as SCRAM-SHA-1

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ mongodb-jndi-datasource
 Tested on Tomcat 6 but should work fine on other Java servers with some configuration changes (JDNI datasource declaration).
 
 **Main changes**
+- v4.0 now is possible to choose the Authentication Mechanism (SCRAM-SHA-1 or MONGODB-CR). Default as SCRAM-SHA-1
 - v3.0 now returns `com.mongodb.client.MongoDatabase` instead of `com.mongodb.DB` (deprecated)
 - v2.0 uses MongoDB java client v3.0.0
 - v1.0 uses MongoDB java client v2.12.2
@@ -30,6 +31,7 @@ These instructions explain how to bind the datasource (DS) to the Bonita web app
 	databaseName="test"
 	username=""
 	password=""
+	authMechanism=""
 	
 	minPoolSize="10"
 	maxPoolSize="100"

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>org.mongodb.datasource</groupId>
 	<artifactId>mongodb-jndi-datasource</artifactId>
 	<name>JNDI pooled datasource for MongoDB</name>
-	<version>3.0</version>
+	<version>4.0</version>
 	
 	<properties>
 		<mongo.client.version>3.0.0</mongo.client.version>

--- a/src/main/java/org/mongodb/datasource/MongoDatasourceConfiguration.java
+++ b/src/main/java/org/mongodb/datasource/MongoDatasourceConfiguration.java
@@ -13,6 +13,8 @@ public class MongoDatasourceConfiguration {
 	private static final String PROP_DB_NAME	= "databaseName";
 	private static final String PROP_USERNAME	= "username";
 	private static final String PROP_PASSWORD	= "password";
+	private static final String PROP_AUTH_MECHANISM = "authMechanism";
+	
 	// Pooling constants
 	private static final String PROP_MIN_POOL_SIZE	= "minPoolSize";
 	private static final String PROP_MAX_POOL_SIZE	= "maxPoolSize";
@@ -25,6 +27,7 @@ public class MongoDatasourceConfiguration {
 	private String databaseName	= null;
 	private String username		= null;
 	private String password		= null;
+	private String authMechanism= null;
 	// Pooling settings
 	private Integer minPoolSize	= null;
 	private Integer maxPoolSize	= null;
@@ -61,6 +64,15 @@ public class MongoDatasourceConfiguration {
 		if ((!isEmptyValue(config.username)) && (isEmptyValue(config.password)))
 			throw new Exception("Missing password property: "+ PROP_PASSWORD);
 		
+		// Optional Authentication Mechanism
+		config.authMechanism = getReferenceValue(reference, PROP_AUTH_MECHANISM);
+		if(isEmptyValue(config.authMechanism) && !isEmptyValue(config.username) && !isEmptyValue(config.password)){			
+			config.authMechanism = "SCRAM-SHA-1";
+		}
+		
+		if(!isEmptyValue(config.authMechanism) && (isEmptyValue(config.username) || isEmptyValue(config.password)) ){
+			throw new Exception("Missing value for mandatory property "+ PROP_USERNAME + " or " + PROP_PASSWORD);
+		}
 		// Pooling settings
 		
 		// Optional minimum pool size
@@ -132,6 +144,7 @@ public class MongoDatasourceConfiguration {
 		// Authentication settings
 		output.append(PROP_DB_NAME).append("=").append(this.databaseName).append(", ");
 		output.append(PROP_USERNAME).append("=").append(this.username).append(", ");
+		output.append(PROP_AUTH_MECHANISM).append("=").append(this.authMechanism).append(",");
 		// Pooling settings
 		output.append(PROP_MIN_POOL_SIZE).append("=").append(this.minPoolSize).append(", ");
 		output.append(PROP_MAX_POOL_SIZE).append("=").append(this.maxPoolSize).append(", ");
@@ -170,5 +183,9 @@ public class MongoDatasourceConfiguration {
 
 	public Integer getMaxWaitTime() {
 		return this.maxWaitTime;
+	}
+	
+	public String getAuthMechanism() {
+		return authMechanism;
 	}
 }

--- a/src/main/java/org/mongodb/datasource/MongoDatasourceFactory.java
+++ b/src/main/java/org/mongodb/datasource/MongoDatasourceFactory.java
@@ -101,7 +101,7 @@ public class MongoDatasourceFactory implements ObjectFactory {
 			// Perform authenticated connection
 			if (LOGGER.isLoggable(Level.FINE))
 				LOGGER.fine("[DS " + dsName + "] Attempting to create authenticated connection...");
-			final MongoCredential credential = MongoCredential.createMongoCRCredential(config.getUsername(), config.getDatabaseName(), config.getPassword().toCharArray());
+			final MongoCredential credential = createMongoCredentials(config);
 			mongoClient = new MongoClient(serverAddress, Arrays.asList(new MongoCredential[] { credential }), options);
 		}
 		else
@@ -113,5 +113,22 @@ public class MongoDatasourceFactory implements ObjectFactory {
 		}
 
 		return new MongoDatasource(mongoClient, config);
+	}
+
+	private static MongoCredential createMongoCredentials(MongoDatasourceConfiguration config) throws Exception {
+		final String authMechanism = config.getAuthMechanism();
+		
+		MongoCredential mongoCredential = null;
+		
+		if ("MONGODB-CR".equalsIgnoreCase(authMechanism)){
+			mongoCredential = MongoCredential.createMongoCRCredential(config.getUsername(), config.getDatabaseName(), config.getPassword().toCharArray());
+		} else if ("SCRAM-SHA-1".equalsIgnoreCase(authMechanism)){
+			mongoCredential = MongoCredential.createScramSha1Credential(config.getUsername(), config.getDatabaseName(), config.getPassword().toCharArray());
+		}
+		
+		if( mongoCredential == null ){
+			throw new Exception("[Mongo Credential " + authMechanism + "] not supported.");
+		}
+		return mongoCredential;
 	}
 }


### PR DESCRIPTION
The current version of mongodb-jndi-datasource 3.0 only support MONGODB-CR authentication mechanism. However, MongoDB 3+
change the default mechanism to SCRAM-SHA-1. 

In this way, using:

MongoDB: 3.2.2 (With authentication enabled)
Mongo Java Driver: 3.2.2

I get the error below:

`
com.mongodb.MongoSecurityException: Exception authenticating
    at com.mongodb.connection.NativeAuthenticator.authenticate(NativeAuthenticator.java:48)
    at com.mongodb.connection.InternalStreamConnectionInitializer.authenticateAll(InternalStreamConnectionInitializer.java:99)
    at com.mongodb.connection.InternalStreamConnectionInitializer.initialize(InternalStreamConnectionInitializer.java:44)
    at com.mongodb.connection.InternalStreamConnection.open(InternalStreamConnection.java:115)
    at com.mongodb.connection.DefaultServerMonitor$ServerMonitorRunnable.run(DefaultServerMonitor.java:128)
    at java.lang.Thread.run(Thread.java:745)
Caused by: com.mongodb.MongoCommandException: Command failed with error 18: 'auth failed' on server ##########:27017. The full response is { "ok" : 0.0, "errmsg" : "auth failed", "code" : 18 }
    at com.mongodb.connection.CommandHelper.createCommandFailureException(CommandHelper.java:170)
    at com.mongodb.connection.CommandHelper.receiveCommandResult(CommandHelper.java:123)
    at com.mongodb.connection.CommandHelper.executeCommand(CommandHelper.java:32)
    at com.mongodb.connection.NativeAuthenticator.authenticate(NativeAuthenticator.java:46)
    ... 5 more
`

This Pull Request changes the mongodb-jndi-datasource component to accept one new mandatory attribute on JNDI resources called "authMechanism" which may be 
SCRAM-SHA-1 or the MONGODB-CR authentication mechanism.

Others mechanisms wasn't mapped becouse I can not test and some are available only in MongoDB Enterprise. 

See: http://stackoverflow.com/questions/18216712/cannot-authenticate-into-mongo-auth-fails
